### PR TITLE
Add a copy command for resources in build scripts

### DIFF
--- a/build-linux.sh
+++ b/build-linux.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 mkdir -p build/linux
+cp -r res build/linux/
 g++ main.cpp -g -ggdb -w -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf -o build/linux/main

--- a/build-mac.sh
+++ b/build-mac.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 mkdir -p build/mac
+cp -r res build/mac/
 g++ main.cpp -g -ggdb -w -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf -o build/mac/main

--- a/build-win.bat
+++ b/build-win.bat
@@ -1,3 +1,4 @@
 @echo off
 mkdir "build/win" 2>NUL
+xcopy /E /I "res" "build/win/res"
 g++ main.cpp -IC:\sdl2\include\SDL2 -LC:\sdl2\lib -g -ggdb -lmingw32 -lSDL2main -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf -o build/win/main


### PR DESCRIPTION
Copying resource folder into build so that it'll be available to built game.

Tested on Windows, verified command syntax for other platforms to be equivalent.